### PR TITLE
fix: rename policy definition uid to id

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1511,7 +1511,7 @@ components:
       properties:
         policy:
           $ref: '#/components/schemas/Policy'
-        uid:
+        id:
           type: string
     Prohibition:
       type: object

--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.html
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.html
@@ -10,7 +10,7 @@
             <mat-label>Access policy</mat-label>
             <mat-select [(ngModel)]="accessPolicy" required>
                 <mat-option *ngFor="let policy of policies" [value]="policy">
-                    {{policy.uid}}
+                    {{policy.id}}
                 </mat-option>
             </mat-select>
         </mat-form-field>
@@ -19,7 +19,7 @@
             <mat-label>Contract policy</mat-label>
             <mat-select [(ngModel)]="contractPolicy" required>
                 <mat-option *ngFor="let policy of policies" [value]="policy">
-                    {{policy.uid}}
+                    {{policy.id}}
                 </mat-option>
             </mat-select>
         </mat-form-field>

--- a/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
+++ b/src/modules/edc-demo/components/contract-definition-editor-dialog/contract-definition-editor-dialog.component.ts
@@ -39,8 +39,8 @@ export class ContractDefinitionEditorDialog implements OnInit {
   ngOnInit(): void {
     this.policyService.getAllPolicies().subscribe(polices => {
       this.policies = polices;
-      this.accessPolicy = this.policies.find(policy => policy.uid === this.contractDefinition.accessPolicyId);
-      this.contractPolicy = this.policies.find(policy => policy.uid === this.contractDefinition.contractPolicyId);
+      this.accessPolicy = this.policies.find(policy => policy.id === this.contractDefinition.accessPolicyId);
+      this.contractPolicy = this.policies.find(policy => policy.id === this.contractDefinition.contractPolicyId);
     });
     this.assetService.getAllAssets().pipe(map(asset => asset.map(a => new Asset(a.properties)))).subscribe(assets => {
       this.availableAssets = assets;
@@ -53,8 +53,8 @@ export class ContractDefinitionEditorDialog implements OnInit {
   }
 
   onSave() {
-    this.contractDefinition.accessPolicyId = this.accessPolicy!.uid;
-    this.contractDefinition.contractPolicyId = this.contractPolicy!.uid;
+    this.contractDefinition.accessPolicyId = this.accessPolicy!.id;
+    this.contractDefinition.contractPolicyId = this.contractPolicy!.id;
     this.contractDefinition.criteria = [];
 
     const ids = this.assets.map(asset => asset.id);

--- a/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.html
+++ b/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.html
@@ -3,7 +3,7 @@
   <!--  ID -->
   <mat-form-field class="form-field-stretch" color="accent" id="form-field-id">
     <mat-label>ID</mat-label>
-    <input [(ngModel)]="policyDefinition.uid" matInput required>
+    <input [(ngModel)]="policyDefinition.id" matInput required>
   </mat-form-field>
 
   <!--  Assigner / Assignee-->

--- a/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.ts
+++ b/src/modules/edc-demo/components/new-policy-dialog/new-policy-dialog.component.ts
@@ -15,7 +15,7 @@ export class NewPolicyDialogComponent implements OnInit {
   };
   policyDefinition: PolicyDefinition = {
     policy: this.policy,
-    uid: ''
+    id: ''
   };
   permissionsJson: string = '';
   prohibitionsJson: string = '';
@@ -43,7 +43,7 @@ export class NewPolicyDialogComponent implements OnInit {
 
     this.dialogRef.close({
       policy: this.policyDefinition.policy,
-      uid: this.policyDefinition.uid
+      id: this.policyDefinition.id
     })
   }
 }

--- a/src/modules/edc-demo/components/policy-view/policy-view.component.html
+++ b/src/modules/edc-demo/components/policy-view/policy-view.component.html
@@ -23,7 +23,7 @@
     <mat-card *ngFor="let policyDef of policyDefinitions" class="policy-card">
       <mat-card-header>
         <mat-icon mat-card-avatar>policy</mat-icon>
-        <mat-card-title><span class="code">{{policyDef.uid}}</span></mat-card-title>
+        <mat-card-title><span class="code">{{policyDef.id}}</span></mat-card-title>
       </mat-card-header>
 
       <mat-card-content>

--- a/src/modules/edc-demo/components/policy-view/policy-view.component.ts
+++ b/src/modules/edc-demo/components/policy-view/policy-view.component.ts
@@ -67,13 +67,13 @@ export class PolicyViewComponent implements OnInit {
 
   delete(policy: PolicyDefinition) {
 
-    const dialogData = ConfirmDialogModel.forDelete("policy", policy.uid);
+    const dialogData = ConfirmDialogModel.forDelete("policy", policy.id);
 
     const ref = this.dialog.open(ConfirmationDialogComponent, {maxWidth: '20%', data: dialogData});
 
     ref.afterClosed().subscribe(res => {
       if (res) {
-        this.policyService.deletePolicy(policy.uid).subscribe(this.errorOrUpdateSubscriber);
+        this.policyService.deletePolicy(policy.id).subscribe(this.errorOrUpdateSubscriber);
       }
     });
   }

--- a/src/modules/edc-dmgmt-client/model/policyDefinition.ts
+++ b/src/modules/edc-dmgmt-client/model/policyDefinition.ts
@@ -14,6 +14,6 @@ import { Policy } from './policy';
 
 export interface PolicyDefinition {
     policy: Policy;
-    uid: string;
+    id: string;
 }
 


### PR DESCRIPTION
## What this PR changes/adds

It renames the `PolicyDefinition's` id field from `uid` to `id` to match the data model of the connector.

## Why it does that

`PolicyDefinition` IDs are not displayed. Thus it is not possible to add a  new `ContractDefinition` via the dashboard.

## Linked Issue(s)

Closes #10 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
