### PR TITLE
ci: release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
       - name: Publish npm library
         if: ${{ !inputs.dry-run }}
         run: npm publish --provenance
-        working-directory: dist/dashboard-core
+        working-directory: dist/@eclipse-edc/dashboard-core
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Validate semver format
         run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^\d+\.\d+\.\d+$'; then
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "::error::Version '${{ inputs.version }}' does not match semver format (MAJOR.MINOR.PATCH)"
             exit 1
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,186 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (semver, e.g. 0.4.0)"
+        required: true
+        type: string
+      dry-run:
+        description: "Dry run (validate and build without publishing)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  validate:
+    name: Validate Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate semver format
+        run: |
+          if ! echo "${{ inputs.version }}" | grep -qE '^\d+\.\d+\.\d+$'; then
+            echo "::error::Version '${{ inputs.version }}' does not match semver format (MAJOR.MINOR.PATCH)"
+            exit 1
+          fi
+
+      - name: Check tag does not exist
+        run: |
+          if git rev-parse "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "::error::Tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+
+      - name: Check branch is main
+        run: |
+          if [ "${{ github.ref_name }}" != "main" ]; then
+            echo "::error::Releases must be created from the main branch (current: ${{ github.ref_name }})"
+            exit 1
+          fi
+
+  test:
+    name: Test
+    needs: validate
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: Cypress Component Tests
+            command: npm run cypress:run:component
+          - name: Cypress E2E Tests
+            command: npm run cypress:run:e2e
+          - name: Karma Service Tests
+            command: npm run lib-build && npm run lib-test -- --no-watch --browsers=ChromeHeadless
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - run: npm ci
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.command }}
+
+  release:
+    name: Release
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: "https://npm.pkg.github.com"
+
+      - run: npm ci
+
+      # --- Version bump ---
+      - name: Bump version in package.json files
+        run: |
+          npm version "${{ inputs.version }}" --no-git-tag-version
+          cd projects/dashboard-core
+          npm version "${{ inputs.version }}" --no-git-tag-version
+
+      # --- Build library ---
+      - name: Build library
+        run: npm run lib-build -- --configuration production
+
+      # --- Publish npm library (with provenance) ---
+      - name: Publish npm library
+        if: ${{ !inputs.dry-run }}
+        run: npm publish --provenance
+        working-directory: dist/dashboard-core
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # --- Build application ---
+      - name: Build application
+        run: npm run build -- --configuration production
+
+      # --- Container image ---
+      - name: Install Cosign
+        if: ${{ !inputs.dry-run }}
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ !inputs.dry-run }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=v${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ inputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push container image
+        id: build-and-push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          push: ${{ !inputs.dry-run }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+
+      - name: Sign container image
+        if: ${{ !inputs.dry-run }}
+        run: cosign sign --yes ghcr.io/${{ github.repository }}@${{ steps.build-and-push.outputs.digest }}
+
+      # --- Changelog ---
+      - name: Generate changelog
+        run: npx conventional-changelog-cli -p angular -i CHANGELOG.md -s -r 1
+
+      - name: Extract release notes
+        run: npx conventional-changelog-cli -p angular -r 1 -o /tmp/RELEASE_NOTES.md
+
+      # --- Git tag and GitHub Release ---
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit version bump and changelog
+        run: |
+          git add package.json projects/dashboard-core/package.json CHANGELOG.md
+          git commit -m "chore(release): v${{ inputs.version }}"
+
+      - name: Create and push tag
+        if: ${{ !inputs.dry-run }}
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin main --follow-tags
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ inputs.version }}" \
+            --title "v${{ inputs.version }}" \
+            --notes-file /tmp/RELEASE_NOTES.md

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
           - name: Cypress E2E Tests
             command: npm run cypress:run:e2e
           - name: Karma Service Tests
-            command: npm run lib-build && npm run lib-test -- --no-watch --browsers=ChromeHeadless
+            command: npm run lib-build && npm run lib-test -- --no-watch --browsers=GitlabHeadlessChrome
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -166,6 +166,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit version bump and changelog
+        if: ${{ !inputs.dry-run }}
         run: |
           git add package.json projects/dashboard-core/package.json CHANGELOG.md
           git commit -m "chore(release): v${{ inputs.version }}"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -18,24 +18,24 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: javascript  # CodeQL JavaScript supports TypeScript
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
 
   cypress-components:
     name: Cypress Component Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
       - run: npm ci
@@ -45,8 +45,8 @@ jobs:
     name: Cypress E2E Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
       - run: npm ci
@@ -56,11 +56,24 @@ jobs:
     name: Karma Service Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
       - run: npm ci
       - run: npm run lib-build
       - run: npm run lib-test -- --no-watch --browsers=GitlabHeadlessChrome
+
+  docker-build:
+    name: Docker Build Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          push: false
+          load: true
+          tags: edc-dashboard:test
 


### PR DESCRIPTION
## What this PR changes/adds

- Introduces a new manual release pipeline with version and dry-run inputs, plus pre-release guard checks for semver format and duplicate tags.
- Adds release-time test gating via a matrix that runs Cypress component tests, Cypress E2E tests, and Karma service tests before any publish/release steps are allowed.
- Implements end-to-end release automation for version bumping, production builds, npm package publish with provenance, GHCR image build/push, Cosign image signing, changelog/release-note generation, git tagging, and GitHub Release creation.
- Hardens workflow supply-chain security by replacing floating action tags with pinned commit SHAs across existing CI workflows (publish.yaml, verify.yaml) and release workflow dependencies.
- Adds CI coverage for container build validity (docker-build job in verify.yaml) and updates Dependabot (.github/dependabot.yml) to group GitHub Action updates for maintainable pinned-action upgrades.

## Why it does that

- Creates a single, repeatable release path so releases are auditable, deterministic, and less error-prone than manual multi-step execution.
- Ensures quality gates are enforced in the release flow itself, reducing the risk of shipping artifacts that bypass core CI test surfaces.
- Improves supply-chain trust by combining immutable action pinning, npm provenance, and signed container artifacts in the same release lifecycle.


## Further notes

- Current release version validation intentionally allows only stable semver (MAJOR.MINOR.PATCH) and excludes prerelease identifiers such as -rc.1.
- The automated changelog/release-notes output depends on conventional commit quality, so release-note fidelity tracks commit-message discipline.


## Who will sponsor this feature?

@ronjaquensel 


## Linked Issue(s)

Closes #312 

